### PR TITLE
update strider-git dependency for heroku's git support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strider-bitbucket",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A bitbucket provider for strider",
   "main": "index.js",
   "scripts": {
@@ -43,7 +43,7 @@
     "passport": "~0.1.17",
     "passport-bitbucket": "~0.1.2",
     "superagent": "~0.15.4",
-    "strider-git": "~0.1.0",
+    "strider-git": "~0.2.0",
     "request": "~2.27.0",
     "lodash": "~2.2.0",
     "step": "0.0.5",


### PR DESCRIPTION
Heroku have much older git:

```
$ hk run "git --version"
Running `git --version` on strider-se7ensky as run.8391:
git version 1.7.0
```

And we have an error cloning project by strider from bitbucket:

```
$ git clone --recursive git@bitbucket.com:repo/path . -b master --single-branch bitbucket 88ms -1
error: unknown option `single-branch'
```

Since this situation is fixed in newer strider-git, please update this dependency.
