### PR TITLE
use .org instead of .com

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -34,7 +34,7 @@ function parseRepo(repo) {
     config: {
       auth: { type: 'ssh' },
       scm: repo.scm,
-      url: 'git://bitbucket.com/' + repo.owner + '/' + repo.slug,
+      url: 'git://bitbucket.org/' + repo.owner + '/' + repo.slug,
       owner: repo.owner,
       repo: repo.slug,
       pull_requests: 'none',


### PR DESCRIPTION
My current strider implementation uses .org, for some reason now started using .com. Its best to keep all with the same domain to prevent multiple firewall rules.

