### PR TITLE
Fix tests

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -285,14 +285,16 @@ function onCommit(context, req, res) {
     return;
   }
 
+  var data;
   try {
     //TODO check json parse (data object)
-    var data = JSON.parse(req.body.payload);
+    data = JSON.parse(req.body.payload);
   } catch (e) {
     res.status(400).send('Invalid json payload');
     return;
   }
 
+  /* jshint validthis: true */
   var client = this.oauth(req.accountConfig());
   var id = data.commits[data.commits.length - 1].raw_node;
   var repositoryFullName = data.repository.absolute_url;
@@ -334,6 +336,7 @@ function onPullRequest(context, req, res) {
   var isPullRequestPrepare = false;
   var data = req.body;
 
+  /* jshint validthis: true */
   var client = this.oauth(req.accountConfig());
 
   if (!data.pullrequest_updated && !data.pullrequest_created) {

--- a/test/test_webhooks.js
+++ b/test/test_webhooks.js
@@ -7,7 +7,7 @@ describe('The Webhooks parsing', function () {
   var payload = require('./example_post')
   describe('.parseHook(payload)', function () {
     it('should parse an example', function () {
-      expect(api.postPayload(payload)).to.eql({
+      expect(api.parseCommitData(payload)).to.eql({
         trigger: {
           type: 'commit',
           author: {


### PR DESCRIPTION
The methods with the failing jshint strict violation checks are called with `.bind` always, as far as I can tell, so this should be safe